### PR TITLE
Add Saucepan (saucepan.ai) as a native extraction source

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,14 @@ After extraction you can:
 
 If the character uses a generic lorebook (e.g. a universe or shared lorebook), this method may not trigger all entries automatically. The only way to pull them is to manually type the trigger keys during entry collection. Those keys can then be sent to the LLM during the build for additional context.
 
+## Saucepan (native extraction)
+
+JAR can also extract characters from [saucepan.ai](https://saucepan.ai) — no browser or Cloudflare workaround needed. Saucepan serves companion definitions through an authenticated API, so extraction is a direct, exact pull (not a reconstruction).
+
+1. **Log in** — open **⚙ Settings → Saucepan** and sign in with your Saucepan handle and password (or paste a Bearer token). The token is stored locally in `settings.local.json`; your password is never stored. A Saucepan session alone is enough to use the app — a JanitorAI login is not required.
+2. **Extract** — paste a `saucepan.ai/companion/…` URL into the sidebar and click **extract**. The full card is pulled directly: description, first message and alternate greetings, example dialogue, tags, and avatar.
+3. **Download** — save the card as PNG or JSON from the *character card* tab, exactly like a JanitorAI character.
+
+Saucepan ships companion definitions as a shuffled list of text fragments padded with decoys (a naive read is scrambled). JAR validates each fragment against its proof hash, drops the decoys, and reassembles the survivors in order — mirroring Saucepan's own client — so the recovered text is exact. Greetings live on a separate endpoint and are reassembled the same way.
+
 License: AGPL-3.0

--- a/public/app.js
+++ b/public/app.js
@@ -229,7 +229,9 @@ async function selectCapture(id) {
 
   const charEl = $('metaChar');
   if (rec.characterId) {
-    const charUrl = `https://janitorai.com/characters/${rec.characterId}`;
+    const charUrl = rec.source === 'saucepan'
+      ? (rec.url || `https://saucepan.ai/companion/${rec.characterId}`)
+      : `https://janitorai.com/characters/${rec.characterId}`;
     charEl.innerHTML = `${t('charLabel')}: <a href="${escapeHtml(charUrl)}" target="_blank" rel="noopener">${escapeHtml(rec.characterName || rec.characterId)}</a>`;
   } else {
     charEl.textContent = rec.characterName || '(unknown)';
@@ -832,11 +834,25 @@ function download() {
 // "extract" button → INSPECT only: read the character's name, avatar, card
 // visibility and lorebooks. Nothing public triggers a generateAlpha run; the
 // private card / closed lorebooks are extracted later, on demand.
+function isSaucepanUrl(url) {
+  return /saucepan\.ai\/companion\//i.test(url);
+}
+
 async function runFromUrl() {
   const url = $('charUrl').value.trim();
   if (!url) { $('autoStatus').textContent = t('pasteFirst'); return; }
+
+  // Saucepan URLs take a different path: a token-authed API extract, no browser.
+  const saucepan = isSaucepanUrl(url);
+  if (saucepan && !state.saucepanReady) {
+    setStatus($('autoStatus'), 'warn', t('saucepanNeedLogin'));
+    openSettings();
+    return;
+  }
+  const busyLabel = saucepan ? t('extracting') : t('inspecting');
+
   $('runBtn').disabled = true;
-  $('autoStatus').textContent = t('inspecting');
+  $('autoStatus').textContent = busyLabel;
 
   // Add a pending entry to the sidebar immediately
   const pendingId = '_pending_' + Date.now();
@@ -847,7 +863,7 @@ async function runFromUrl() {
   li.classList.add('active');
   li.innerHTML = `
     <div class="li-top">
-      <span class="li-char extracting">${t('inspecting')}</span>
+      <span class="li-char extracting">${busyLabel}</span>
       <span class="li-time">${fmtTime(Date.now())}</span>
     </div>
     <div class="li-preview">${escapeHtml(url)}</div>`;
@@ -855,13 +871,13 @@ async function runFromUrl() {
   document.querySelectorAll('#captureList li').forEach((el) =>
     el.classList.toggle('active', el.dataset.id === pendingId));
 
-  // Show inspecting state in the detail panel
+  // Show working state in the detail panel
   $('detailBody').classList.add('hidden');
   $('detailEmpty').classList.remove('hidden');
-  $('detailEmpty').innerHTML = `<span class="extracting">${t('inspecting')}</span>`;
+  $('detailEmpty').innerHTML = `<span class="extracting">${busyLabel}</span>`;
 
   try {
-    const r = await api('/api/inspect', {
+    const r = await api(saucepan ? '/api/saucepan/extract' : '/api/inspect', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url }),
@@ -870,7 +886,7 @@ async function runFromUrl() {
     li.remove();
     await loadList();
     await selectCapture(r.id);
-    $('autoStatus').textContent = t('inspectDone');
+    $('autoStatus').textContent = saucepan ? t('extractDone') : t('inspectDone');
   } catch (e) {
     li.remove();
     await loadList();
@@ -957,6 +973,13 @@ async function deleteCapture() {
 }
 
 // ---- settings ----
+function renderSaucepanStatus() {
+  const el = $('saucepanStatus');
+  if (!el) return;
+  if (state.saucepanReady) setStatus(el, 'check', t('saucepanLoggedIn'));
+  else el.textContent = t('saucepanNotLoggedIn');
+}
+
 async function openSettings() {
   const s = await api('/api/settings');
   $('setLang').value = currentLang;
@@ -964,7 +987,40 @@ async function openSettings() {
   $('setApiKey').value = s.apiKey || '';
   $('setModel').value = s.model || '';
   $('setDontHideWindow').checked = !!s.dontHideBrowserWindow;
+  renderSaucepanStatus();
   $('settingsDialog').showModal();
+}
+
+// Log in to Saucepan from the settings dialog (handle + password → stored token).
+async function saucepanLogin() {
+  const handle = $('setSaucepanHandle').value.trim();
+  const password = $('setSaucepanPassword').value;
+  if (!handle || !password) { setStatus($('saucepanStatus'), 'warn', t('saucepanNeedCreds')); return; }
+  $('saucepanLoginBtn').disabled = true;
+  setStatus($('saucepanStatus'), 'unlock', t('saucepanLoggingIn'));
+  try {
+    const r = await api('/api/saucepan/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle, password }),
+    });
+    state.saucepanReady = !!r.loggedIn;
+    $('setSaucepanPassword').value = '';
+    renderSaucepanStatus();
+    unlockUI();
+  } catch (e) {
+    setStatus($('saucepanStatus'), 'x', e.message);
+  } finally {
+    $('saucepanLoginBtn').disabled = false;
+  }
+}
+
+async function saucepanLogout() {
+  try {
+    await api('/api/saucepan/logout', { method: 'POST' });
+  } catch (_) { /* clear locally regardless */ }
+  state.saucepanReady = false;
+  renderSaucepanStatus();
 }
 async function saveSettings(e) {
   e.preventDefault();
@@ -990,17 +1046,20 @@ function unlockUI() {
 
 async function checkStatus() {
   $('loginStatus').textContent = t('checkingSession');
-  try {
-    const data = await api('/api/status');
-    if (data.loggedIn) {
-      setStatus($('loginStatus'), 'check', t('loggedIn'));
-      unlockUI();
-    } else {
-      $('loginStatus').textContent = t('notLoggedIn');
-    }
-  } catch (_) {
-    $('loginStatus').textContent = '';
+  // Either source unlocks the UI: JanitorAI (browser session) or Saucepan (token).
+  const [jan, sauce] = await Promise.all([
+    api('/api/status').catch(() => ({ loggedIn: false })),
+    api('/api/saucepan/status').catch(() => ({ loggedIn: false })),
+  ]);
+  state.saucepanReady = !!sauce.loggedIn;
+  if (jan.loggedIn) {
+    setStatus($('loginStatus'), 'check', t('loggedIn'));
+  } else if (sauce.loggedIn) {
+    setStatus($('loginStatus'), 'check', t('saucepanReady'));
+  } else {
+    $('loginStatus').textContent = t('notLoggedIn');
   }
+  if (jan.loggedIn || sauce.loggedIn) unlockUI();
 }
 
 // ---- JanitorAI login ----
@@ -1053,6 +1112,8 @@ $('downloadBtn').addEventListener('click', download);
 $('deleteBtn').addEventListener('click', deleteCapture);
 $('settingsBtn').addEventListener('click', openSettings);
 $('saveSettings').addEventListener('click', saveSettings);
+$('saucepanLoginBtn').addEventListener('click', saucepanLogin);
+$('saucepanLogoutBtn').addEventListener('click', saucepanLogout);
 // Manual language switch — applies immediately and persists across sessions.
 $('setLang').addEventListener('change', () => setLang($('setLang').value, true));
 

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -125,6 +125,23 @@ const I18N = {
     howLi1: 'download the extracted lorebook content as a plain .txt file (no keys or rules).',
     howLi2: 'send the entries to a chosen model (along with the character card and description for context) and have it build a proper lorebook for you.',
     howUniverse: 'if the target character uses a generic lorebook (e.g. a universe lorebook or a sex-positions lorebook), this method may not trigger all entries automatically. the only way to pull them is to manually type the keys during entry collection. those keys can then be sent during the LLM build for additional context.',
+
+    // Saucepan (native extraction)
+    extractDone: 'extracted',
+    saucepanReady: 'saucepan ready',
+    saucepanNeedLogin: 'log in to saucepan first (settings)',
+    saucepanTitle: 'Saucepan (native extraction)',
+    saucepanHint: 'optional — extract characters from a saucepan.ai companion URL. no browser needed; sign in once and the token is stored locally.',
+    saucepanHandle: 'handle',
+    saucepanHandlePh: 'saucepan handle',
+    saucepanPassword: 'password',
+    saucepanPasswordPh: 'password (not stored)',
+    saucepanLoginBtn: 'log in to saucepan',
+    saucepanLogoutBtn: 'clear token',
+    saucepanLoggingIn: 'logging in…',
+    saucepanLoggedIn: 'logged in',
+    saucepanNotLoggedIn: 'not logged in',
+    saucepanNeedCreds: 'enter handle and password',
   },
 
   ru: {
@@ -246,6 +263,23 @@ const I18N = {
     howLi1: 'скачать извлечённое содержимое лорбука в .txt (без ключей и правил).',
     howLi2: 'отправить эти записи выбранной модели (вместе с карточкой персонажа и её описанием для контекста) и попросить её собрать лорбук вместо вас.',
     howUniverse: 'если целевой персонаж использует какой-то общий лорбук (например, лорбук вселенной или лорбук для поз в сексе), то этот метод может не вызвать все записи автоматически. единственный способ их вытащить — самостоятельно вписать ключи при сборе записей. эти ключи потом могут быть отправлены при сборке с помощью LLM для дополнительного контекста.',
+
+    // Saucepan (нативная экстракция)
+    extractDone: 'извлечено',
+    saucepanReady: 'saucepan готов',
+    saucepanNeedLogin: 'сначала войдите в saucepan (настройки)',
+    saucepanTitle: 'Saucepan (нативная экстракция)',
+    saucepanHint: 'опционально — извлечение персонажей по ссылке saucepan.ai. браузер не нужен; войдите один раз, и токен сохранится локально.',
+    saucepanHandle: 'логин',
+    saucepanHandlePh: 'логин saucepan',
+    saucepanPassword: 'пароль',
+    saucepanPasswordPh: 'пароль (не сохраняется)',
+    saucepanLoginBtn: 'войти в saucepan',
+    saucepanLogoutBtn: 'очистить токен',
+    saucepanLoggingIn: 'вход…',
+    saucepanLoggedIn: 'вы вошли',
+    saucepanNotLoggedIn: 'не авторизован',
+    saucepanNeedCreds: 'введите логин и пароль',
   },
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -328,6 +328,19 @@
         <input type="checkbox" id="setDontHideWindow" />
         <span data-i18n="dontHideWindowToggle">don't hide browser window while extracting</span>
       </label>
+
+      <h2 data-i18n="saucepanTitle">Saucepan (native extraction)</h2>
+      <p class="muted" data-i18n="saucepanHint">optional — extract characters from a saucepan.ai companion URL. no browser needed; sign in once and the token is stored locally.</p>
+      <span id="saucepanStatus" class="muted"></span>
+      <label data-i18n="saucepanHandle">handle</label>
+      <input id="setSaucepanHandle" type="text" data-i18n-ph="saucepanHandlePh" placeholder="saucepan handle" autocomplete="off" />
+      <label data-i18n="saucepanPassword">password</label>
+      <input id="setSaucepanPassword" type="password" data-i18n-ph="saucepanPasswordPh" placeholder="password (not stored)" autocomplete="off" />
+      <div class="row">
+        <button type="button" id="saucepanLoginBtn" class="ghost small"><svg class="icon"><use href="#i-unlock"/></svg><span data-i18n="saucepanLoginBtn">log in to saucepan</span></button>
+        <button type="button" id="saucepanLogoutBtn" class="ghost small" data-i18n="saucepanLogoutBtn">clear token</button>
+      </div>
+
       <div class="row end">
         <button value="cancel" class="ghost" data-i18n="cancelBtn">cancel</button>
         <button id="saveSettings" value="default" class="primary" data-i18n="saveBtn">save</button>

--- a/src/captureStore.js
+++ b/src/captureStore.js
@@ -53,7 +53,7 @@ function saveInspection(record) {
     id,
     ts: Date.now(),
     url: record.url || '',
-    source: 'inspect',
+    source: record.source || 'inspect',
     characterId: record.characterId || '',
     characterName: record.characterName || '',
     meta: record.meta || null,

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const { fetchPublicLorebooks, publicEntryContents } = require('./publiclore');
 const { enterExtractionMode, restoreProfile } = require('./profile');
 const { ensureUserMacroPersona, deletePersona } = require('./personas');
 const { countTokens } = require('./tokenizer');
+const saucepan = require('./saucepan');
 
 const PORT = Number(process.env.PORT) || 4577;
 const SETTINGS_FILE = path.join(__dirname, '..', 'settings.local.json');
@@ -33,6 +34,7 @@ function loadSettings() {
     apiKey: '',
     model: '',
     dontHideBrowserWindow: false,
+    saucepanToken: '',
   };
   try {
     if (fs.existsSync(SETTINGS_FILE)) {
@@ -44,6 +46,9 @@ function loadSettings() {
 function saveSettings(s) {
   fs.writeFileSync(SETTINGS_FILE, JSON.stringify(s, null, 2), 'utf8');
 }
+
+// Restore a persisted Saucepan bearer token into the module on boot.
+saucepan.setToken(loadSettings().saucepanToken || '');
 
 // ---- live capture notifications (SSE) ----
 const sseClients = new Set();
@@ -777,17 +782,88 @@ app.post('/api/save-character', (req, res) => {
   }
 });
 
-app.get('/api/settings', (req, res) => res.json(loadSettings()));
+app.get('/api/settings', (req, res) => {
+  // Never expose the Saucepan bearer token to the client — status is reported
+  // via /api/saucepan/status instead.
+  const { saucepanToken, ...safe } = loadSettings();
+  res.json(safe);
+});
 app.post('/api/settings', (req, res) => {
   const cur = loadSettings();
+  // Spread `cur` first so unrelated persisted fields (e.g. saucepanToken) survive.
   const next = {
+    ...cur,
     baseUrl: req.body.baseUrl ?? cur.baseUrl,
     apiKey: req.body.apiKey ?? cur.apiKey,
     model: req.body.model ?? cur.model,
     dontHideBrowserWindow: req.body.dontHideBrowserWindow ?? cur.dontHideBrowserWindow,
   };
   saveSettings(next);
-  res.json(next);
+  const { saucepanToken, ...safe } = next;
+  res.json(safe);
+});
+
+// ---- Saucepan (saucepan.ai) native extraction -----------------------------
+// A separate source from JanitorAI: no browser needed. The companion definition
+// comes straight from Saucepan's authed REST API and is reassembled from its
+// obfuscated fragments (see src/saucepan.js). A bearer token is required —
+// obtained via handle/password login or pasted directly — and persisted locally.
+
+function persistSaucepanToken(tok) {
+  saucepan.setToken(tok);
+  saveSettings({ ...loadSettings(), saucepanToken: saucepan.getToken() });
+}
+
+app.get('/api/saucepan/status', (_req, res) => {
+  res.json({ loggedIn: saucepan.hasToken() });
+});
+
+app.post('/api/saucepan/login', async (req, res) => {
+  try {
+    const { handle, password } = req.body || {};
+    if (!handle || !password) return res.status(400).json({ error: 'handle and password are required' });
+    const tok = await saucepan.login(handle, password);
+    persistSaucepanToken(tok);
+    res.json({ ok: true, loggedIn: true });
+  } catch (e) {
+    res.status(502).json({ error: String(e.message || e) });
+  }
+});
+
+app.post('/api/saucepan/set-token', (req, res) => {
+  const tok = String((req.body && req.body.token) || '').trim();
+  if (!tok) return res.status(400).json({ error: 'token is required' });
+  persistSaucepanToken(tok);
+  res.json({ ok: true, loggedIn: true });
+});
+
+app.post('/api/saucepan/logout', (_req, res) => {
+  persistSaucepanToken('');
+  res.json({ ok: true, loggedIn: false });
+});
+
+// Extract a Saucepan companion by URL and save it as an inspection record so it
+// shows in the sidebar and populates the character-card form (same shape as
+// /api/inspect). The card is complete — no follow-up capture needed.
+app.post('/api/saucepan/extract', async (req, res) => {
+  try {
+    const url = String((req.body && req.body.url) || '').trim();
+    if (!url) return res.status(400).json({ error: 'url is required' });
+    const { companionId, character } = await saucepan.extractCompanion(url);
+    const rec = store.saveInspection({
+      url,
+      characterId: companionId,
+      characterName: character.name,
+      character,
+      avatarBase64: character.avatarBase64 || '',
+      cardPublic: true,
+      source: 'saucepan',
+    });
+    broadcast('capture', { id: rec.id });
+    res.json({ id: rec.id, characterName: rec.characterName, character });
+  } catch (e) {
+    res.status(e.status || 500).json({ error: String(e.message || e) });
+  }
 });
 
 app.get('/api/events', (req, res) => {

--- a/src/saucepan.js
+++ b/src/saucepan.js
@@ -1,0 +1,233 @@
+'use strict';
+
+/**
+ * Saucepan (saucepan.ai) native extraction.
+ *
+ * Unlike the JanitorAI path, Saucepan needs no browser: its companion
+ * definition is available directly from the authenticated REST API. The catch
+ * is that definitions ship as a SHUFFLED list of text fragments padded with
+ * decoy fragments — a naive join is garbled. Each real fragment carries a
+ * `proof` hash that the decoys fail; reassembly validates the proof, orders the
+ * survivors by `key ^ mask`, and concatenates. Ported from Saucepan's own web
+ * client so the output matches byte-for-byte.
+ *
+ * Data comes from two endpoints:
+ *   GET /api/v1/companion/definition?companion_id=ID  -> named prose sections
+ *       (Companion Core, Example Dialogue, Advanced Prompt, Response Formatting)
+ *   GET /api/v2/companions/ID                          -> metadata + the body
+ *       fragments + starting scenarios (the greetings; absent from definition)
+ */
+
+const zlib = require('node:zlib');
+
+const SAUCEPAN_BASE = 'https://saucepan.ai';
+const SAUCEPAN_ORIGIN = 'https://saucepan.ai';
+const SAUCEPAN_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+
+// ---- persisted bearer token (set from settings on boot / via the login route) ----
+let token = '';
+function setToken(t) { token = String(t || '').trim(); }
+function getToken() { return token; }
+function hasToken() { return !!token; }
+
+function headers(withAuth) {
+  const h = {
+    'User-Agent': SAUCEPAN_UA,
+    Accept: '*/*',
+    // Negotiate gzip/deflate/br so undici auto-decompresses; the zstd fallback
+    // below covers a server that ignores this and answers zstd anyway.
+    'Accept-Encoding': 'gzip, deflate, br',
+    Origin: SAUCEPAN_ORIGIN,
+    Referer: `${SAUCEPAN_ORIGIN}/`,
+    'x-saucepan-client-version': '1',
+  };
+  if (withAuth && token) h.Authorization = `Bearer ${token}`;
+  return h;
+}
+
+async function readBody(response) {
+  const ce = (response.headers.get('content-encoding') || '').toLowerCase();
+  if (ce.includes('zstd')) {
+    const buf = Buffer.from(await response.arrayBuffer());
+    if (typeof zlib.zstdDecompressSync !== 'function') {
+      throw new Error('server returned zstd but this Node lacks zlib.zstdDecompress (needs Node >= 22.15)');
+    }
+    return zlib.zstdDecompressSync(buf).toString('utf8');
+  }
+  return response.text();
+}
+
+// ---- fragment reassembly (verbatim port of Saucepan's client scheme) ----
+const FNV_OFFSET = 2166136261;
+const FNV_PRIME = 16777619;
+
+function rotl(value, bits) {
+  return ((value << bits) | (value >>> (32 - bits))) >>> 0;
+}
+
+function fragmentHash(mask, derivedKey, text) {
+  const bytes = new TextEncoder().encode(text);
+  let h = (FNV_OFFSET ^ rotl(mask, 7) ^ rotl(derivedKey, 13)) >>> 0;
+  for (const b of bytes) {
+    h ^= b;
+    h = Math.imul(h, FNV_PRIME) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * Reassemble a `{ fragments, mask }` content object into prose, dropping decoys.
+ * @param {{fragments?: Array<{key:number, proof:number, text:string}>, mask?:number}} content
+ * @returns {string}
+ */
+function assembleFragments(content) {
+  const fragments = Array.isArray(content && content.fragments) ? content.fragments : [];
+  const mask = ((content && content.mask) || 0) >>> 0;
+  return fragments
+    .filter((f) => {
+      if (!f || typeof f.text !== 'string') return false;
+      const derivedKey = (f.key ^ mask) >>> 0;
+      return fragmentHash(mask, derivedKey, f.text) === (f.proof >>> 0);
+    })
+    .sort((a, b) => ((a.key ^ mask) >>> 0) - ((b.key ^ mask) >>> 0))
+    .map((f) => f.text)
+    .join('');
+}
+
+// ---- API helpers ----
+async function fetchJson(path, withAuth) {
+  const response = await fetch(`${SAUCEPAN_BASE}${path}`, { method: 'GET', headers: headers(withAuth) });
+  let data = null;
+  try { data = JSON.parse(await readBody(response)); } catch (_) { /* leave null */ }
+  return { ok: response.ok, status: response.status, data };
+}
+
+/** Extract the companion UUID from a saucepan.ai/companion/<id> URL. */
+function parseCompanionId(url) {
+  const m = String(url || '').match(/saucepan\.ai\/companion\/([a-f0-9-]{8,64})/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Log in with handle + password. Returns the bearer token (and stores it).
+ * @throws on bad credentials / network error
+ */
+async function login(handle, password) {
+  const response = await fetch(`${SAUCEPAN_BASE}/api/v1/auth/sign_in_password`, {
+    method: 'POST',
+    headers: { ...headers(false), 'Content-Type': 'application/json', Referer: `${SAUCEPAN_ORIGIN}/sign-in` },
+    body: JSON.stringify({ handle: String(handle || '').trim(), password: String(password || '') }),
+  });
+  let data = {};
+  try { data = JSON.parse(await readBody(response)); } catch (_) { /* non-JSON */ }
+  if (!response.ok) {
+    throw new Error((data && data.error && data.error.message) || `Saucepan HTTP ${response.status}`);
+  }
+  const t = data && (data.token || data.access_token || data.session_token || data.sessionToken);
+  if (!t) throw new Error('login succeeded but no token was returned');
+  setToken(t);
+  return t;
+}
+
+/** Download the companion's avatar and return it as a data: URI (or '' on failure). */
+async function fetchAvatar(imageId) {
+  if (!imageId) return '';
+  try {
+    const response = await fetch(`${SAUCEPAN_BASE}/cdn/${encodeURIComponent(imageId)}/card`, {
+      method: 'GET',
+      headers: { 'User-Agent': SAUCEPAN_UA, Accept: 'image/avif,image/webp,image/*,*/*;q=0.8', Referer: `${SAUCEPAN_ORIGIN}/` },
+    });
+    if (!response.ok) return '';
+    const len = parseInt(response.headers.get('content-length'), 10);
+    if (len > MAX_IMAGE_BYTES) return '';
+    const buf = Buffer.from(await response.arrayBuffer());
+    if (buf.length > MAX_IMAGE_BYTES) return '';
+    const type = response.headers.get('content-type') || 'image/jpeg';
+    return `data:${type};base64,${buf.toString('base64')}`;
+  } catch (_) {
+    return '';
+  }
+}
+
+/**
+ * Fetch a Saucepan companion by URL and build a JAR character object.
+ * Requires a stored bearer token (definition + scenarios are auth-gated).
+ * @param {string} url  saucepan.ai/companion/<id>
+ * @returns {Promise<{companionId:string, character:object}>}
+ */
+async function extractCompanion(url) {
+  if (!hasToken()) {
+    throw Object.assign(new Error('no Saucepan token configured — log in first'), { status: 401 });
+  }
+  const companionId = parseCompanionId(url);
+  if (!companionId) {
+    throw Object.assign(new Error('not a Saucepan companion URL'), { status: 400 });
+  }
+
+  const [defRes, compRes] = await Promise.all([
+    fetchJson(`/api/v1/companion/definition?companion_id=${encodeURIComponent(companionId)}`, true),
+    fetchJson(`/api/v2/companions/${encodeURIComponent(companionId)}`, true),
+  ]);
+
+  if (!defRes.ok) {
+    const msg = (defRes.data && defRes.data.error && defRes.data.error.message) || `Saucepan HTTP ${defRes.status}`;
+    throw Object.assign(new Error(msg), { status: defRes.status === 401 ? 401 : 502 });
+  }
+
+  // Named prose sections from the definition endpoint.
+  const sections = {};
+  for (const s of (defRes.data && Array.isArray(defRes.data.sections) ? defRes.data.sections : [])) {
+    if (s && s.title && s.content) sections[s.title] = assembleFragments(s.content);
+  }
+
+  const companion = (compRes.data && compRes.data.companion) || null;
+  if (!compRes.ok || !companion) {
+    console.warn(`[saucepan] greetings/metadata unavailable (companions/${companionId} HTTP ${compRes.status})`);
+  }
+
+  // Body: prefer the definition's "Companion Core", fall back to the v2 body.
+  let description = sections['Companion Core'] || '';
+  if (!description && companion && companion.full_description_fragments) {
+    description = assembleFragments(companion.full_description_fragments);
+  }
+
+  // Greetings live only on the v2 companion as starting scenarios.
+  const greetings = [];
+  for (const sc of (companion && Array.isArray(companion.starting_scenarios_fragments) ? companion.starting_scenarios_fragments : [])) {
+    const text = assembleFragments(sc && sc.message);
+    if (text && text.trim()) greetings.push(text);
+  }
+
+  // Advanced Prompt / Response Formatting have no dedicated V2 field here; keep
+  // them (labeled) in creator notes so nothing authored is silently dropped.
+  const notesParts = [];
+  const shortDesc = (companion && companion.short_description) ? String(companion.short_description).trim() : '';
+  if (shortDesc) notesParts.push(shortDesc);
+  if (sections['Advanced Prompt']) notesParts.push(`--- Advanced Prompt ---\n${sections['Advanced Prompt']}`);
+  if (sections['Response Formatting Instructions']) notesParts.push(`--- Response Formatting ---\n${sections['Response Formatting Instructions']}`);
+
+  const imageId = companion && companion.image && companion.image.id;
+  const avatarBase64 = await fetchAvatar(imageId);
+
+  const character = {
+    name: (companion && (companion.display_name || companion.name)) || 'Unknown',
+    avatarBase64,
+    description,
+    personality: '',
+    scenario: '',
+    firstMessage: greetings[0] || '',
+    alternateGreetings: greetings.slice(1),
+    exampleMessages: sections['Example Dialogue'] || '',
+    creatorNotes: notesParts.join('\n\n'),
+    tags: (companion && Array.isArray(companion.tags)) ? companion.tags : [],
+    definitionSource: 'saucepan',
+  };
+
+  return { companionId, character };
+}
+
+module.exports = {
+  setToken, getToken, hasToken, login, extractCompanion, parseCompanionId,
+  assembleFragments, // exported for tests
+};


### PR DESCRIPTION
Adds [saucepan.ai](https://saucepan.ai) as a second extraction source alongside JanitorAI.

Unlike JanitorAI, Saucepan exposes companion definitions through an authenticated REST API, so extraction needs **no browser and no Cloudflare workaround** — it's a direct, exact pull rather than a generateAlpha reconstruction. It slots in below the existing browser machinery and reuses the sidebar, character-card form, and PNG/JSON download unchanged.

## Usage
1. **⚙ Settings → Saucepan** — sign in with your Saucepan handle + password (or paste a Bearer token). The token is stored in `settings.local.json`; the password is never stored. A Saucepan session alone unlocks the UI (a JanitorAI login isn't required).
2. Paste a `saucepan.ai/companion/…` URL into the existing **extract** box. The full card is pulled: description, first message + alternate greetings, example dialogue, tags, and avatar.
3. Download as PNG/JSON from the *character card* tab, same as a JanitorAI character.

## How the extraction works
Saucepan ships companion definitions as a **shuffled** list of text fragments padded with **decoy** fragments — a naive read is scrambled. Each real fragment carries a `proof` hash the decoys fail; reassembly validates the proof (FNV-1a seeded from the section `mask` and `key ^ mask`), drops the decoys, and orders the survivors by `key ^ mask`. This mirrors Saucepan's own web client, so the recovered text is exact. The body + prompt sections come from `/api/v1/companion/definition`; greetings come from `/api/v2/companions/{id}` and are reassembled the same way.

## Changes
- **`src/saucepan.js`** (new) — login, companion fetch, fragment reassembly, avatar download, and JAR character build. Uses only Node built-ins (`fetch`, `node:zlib`); **no new dependencies**.
- **`src/index.js`** — `/api/saucepan/{status,login,set-token,logout,extract}` routes; the token is persisted locally and never returned to the client; extracted cards are saved as inspection records.
- **`public/`** — saucepan.ai URLs route through the existing extract box; a Saucepan login section in Settings; either source unlocks the UI. EN + RU strings added.
- **`src/captureStore.js`** — `saveInspection` honors an explicit `source` (defaults to `inspect`).

## Field mapping
`Companion Core` → description · `Example Dialogue` → example messages · starting scenarios → first message + alternate greetings · tags → tags · short description → creator notes. `Advanced Prompt` / `Response Formatting Instructions` have no dedicated card field, so they're preserved (labeled) in creator notes rather than dropped.

## Testing
End-to-end against live saucepan.ai: login, token persistence across restart, and native extraction of several companions — description, first message, alternate greetings, example dialogue, tags, and avatar all reassemble correctly, and the save path writes a valid `chara_card_v2` (+ avatar).

## Notes
- A Saucepan account is required (definitions + greetings are auth-gated).
- The fragment reassembly mirrors Saucepan's current client scheme; if they change it, this will need updating.
